### PR TITLE
Move shared data to Storage struct to limit blocking during App update

### DIFF
--- a/software/teachee-desktop/src/app.rs
+++ b/software/teachee-desktop/src/app.rs
@@ -1,12 +1,11 @@
 use std::{
     f64::consts::TAU,
     sync::{Arc, Mutex},
-    thread,
 };
 
 use eframe::egui::*;
 
-use crate::{storage::Storage, usb_manager};
+use crate::{storage::Storage, usb_manager::USBManager};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 enum Channel {
@@ -26,10 +25,9 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+    pub fn new() -> Self {
         let storage = Arc::new(Mutex::new(Storage::default()));
-        let usb_storage = Arc::clone(&storage);
-        thread::spawn(move || usb_manager::usb_manager(usb_storage));
+        USBManager::new(Arc::clone(&storage)).start();
         Self {
             storage,
             ..Self::default()

--- a/software/teachee-desktop/src/lib.rs
+++ b/software/teachee-desktop/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod app;
 pub mod storage;
+pub mod usb_manager;

--- a/software/teachee-desktop/src/main.rs
+++ b/software/teachee-desktop/src/main.rs
@@ -3,7 +3,7 @@
 
 use eframe::{self, epaint::Vec2, NativeOptions, Theme};
 
-use teachee_desktop::storage::Storage;
+use teachee_desktop::app::App;
 
 fn main() {
     tracing_subscriber::fmt::init();
@@ -14,13 +14,5 @@ fn main() {
         ..NativeOptions::default()
     };
 
-    eframe::run_native(
-        "TeachEE",
-        options,
-        Box::new(|_cc| {
-            let storage = Storage::default();
-            storage.clone().spawn_usb_manager_thread();
-            Box::new(storage)
-        }),
-    );
+    eframe::run_native("TeachEE", options, Box::new(|_cc| Box::new(App::new(_cc))));
 }

--- a/software/teachee-desktop/src/main.rs
+++ b/software/teachee-desktop/src/main.rs
@@ -14,5 +14,5 @@ fn main() {
         ..NativeOptions::default()
     };
 
-    eframe::run_native("TeachEE", options, Box::new(|_cc| Box::new(App::new(_cc))));
+    eframe::run_native("TeachEE", options, Box::new(|_cc| Box::new(App::new())));
 }

--- a/software/teachee-desktop/src/storage.rs
+++ b/software/teachee-desktop/src/storage.rs
@@ -1,33 +1,14 @@
-use std::{
-    sync::{Arc, Mutex},
-    thread,
-    time::Duration,
-};
-
-use eframe::egui;
-
-use crate::app::App;
-
 #[derive(Debug, Default, Clone)]
 pub struct Storage {
-    pub app: Arc<Mutex<App>>,
+    // TODO: Add buffer and other shared data
+    flag: bool,
 }
 
 impl Storage {
-    fn usb_manager(self) {
-        loop {
-            thread::sleep(Duration::from_secs(1));
-            self.app.lock().unwrap().flip_flag();
-        }
+    pub fn read_flag(&self) -> bool {
+        self.flag
     }
-
-    pub fn spawn_usb_manager_thread(self) {
-        thread::spawn(move || self.usb_manager());
-    }
-}
-
-impl eframe::App for Storage {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
-        self.app.lock().unwrap().update(ctx, frame);
+    pub fn flip_flag(&mut self) {
+        self.flag = !self.flag;
     }
 }

--- a/software/teachee-desktop/src/storage.rs
+++ b/software/teachee-desktop/src/storage.rs
@@ -8,6 +8,7 @@ impl Storage {
     pub fn read_flag(&self) -> bool {
         self.flag
     }
+
     pub fn flip_flag(&mut self) {
         self.flag = !self.flag;
     }

--- a/software/teachee-desktop/src/usb_manager.rs
+++ b/software/teachee-desktop/src/usb_manager.rs
@@ -6,9 +6,24 @@ use std::{
 
 use crate::storage::Storage;
 
-pub fn usb_manager(storage: Arc<Mutex<Storage>>) {
-    loop {
-        thread::sleep(Duration::from_secs(1));
-        storage.lock().unwrap().flip_flag();
+#[derive(Debug, Default)]
+pub struct USBManager {
+    storage: Arc<Mutex<Storage>>,
+}
+
+impl USBManager {
+    pub fn new(storage: Arc<Mutex<Storage>>) -> Self {
+        Self { storage }
+    }
+
+    pub fn start(self) {
+        thread::spawn(move || self.usb_manager());
+    }
+
+    pub fn usb_manager(self) {
+        loop {
+            thread::sleep(Duration::from_secs(1));
+            self.storage.lock().unwrap().flip_flag();
+        }
     }
 }

--- a/software/teachee-desktop/src/usb_manager.rs
+++ b/software/teachee-desktop/src/usb_manager.rs
@@ -1,0 +1,14 @@
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+    time::Duration,
+};
+
+use crate::storage::Storage;
+
+pub fn usb_manager(storage: Arc<Mutex<Storage>>) {
+    loop {
+        thread::sleep(Duration::from_secs(1));
+        storage.lock().unwrap().flip_flag();
+    }
+}


### PR DESCRIPTION
- Move shared data to Storage struct, only contains a bool for now. This struct is shared between the App thread and usb manager thread.
- New usb_manager function which runs on the usb manager thread

Signed-off-by: Eric Yang <e.yang@queensu.ca>