### PR TITLE
Move Lint Job over to SVLint Fork

### DIFF
--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -20,7 +20,6 @@ jobs:
             rtl/examples/*/*.sv
         env:
           SVLINT_CONFIG: rtl/.svlint.toml
-      # - run: SVLINT_CONFIG=rtl/.svlint.toml svlint rtl/axis/*.sv rtl/ft232h/*.sv rtl/xadc/*.sv rtl/examples/*/*.sv 
 
   # This job is a modified version of what is shown on this blog post: https://purisa.me/blog/testing-hdl-on-github/
   vunit:

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -19,7 +19,7 @@ jobs:
             rtl/xadc/*.sv
             rtl/examples/*/*.sv
         env:
-          SVLINT_CONFIG=rtl/.svlint.toml
+          SVLINT_CONFIG: rtl/.svlint.toml
       # - run: SVLINT_CONFIG=rtl/.svlint.toml svlint rtl/axis/*.sv rtl/ft232h/*.sv rtl/xadc/*.sv rtl/examples/*/*.sv 
 
   # This job is a modified version of what is shown on this blog post: https://purisa.me/blog/testing-hdl-on-github/

--- a/.github/workflows/rtl.yml
+++ b/.github/workflows/rtl.yml
@@ -11,14 +11,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
+      - uses: teachee-capstone/svlint-action@v1.03
         with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
-
-      - run: cargo install svlint
-      - run: SVLINT_CONFIG=rtl/.svlint.toml svlint rtl/axis/*.sv rtl/ft232h/*.sv rtl/xadc/*.sv rtl/examples/*/*.sv 
+          files: |
+            rtl/axis/*.sv
+            rtl/ft232h/*.sv
+            rtl/xadc/*.sv
+            rtl/examples/*/*.sv
+        env:
+          SVLINT_CONFIG=rtl/.svlint.toml
+      # - run: SVLINT_CONFIG=rtl/.svlint.toml svlint rtl/axis/*.sv rtl/ft232h/*.sv rtl/xadc/*.sv rtl/examples/*/*.sv 
 
   # This job is a modified version of what is shown on this blog post: https://purisa.me/blog/testing-hdl-on-github/
   vunit:


### PR DESCRIPTION
The svlint GitHub action was using an older version of SVLint. I forked it to the teachee-capstone org and fixed the issue. This revised lint action is far faster than the way I did it before by compiling and installing from scratch with cargo each time.