### PR TITLE
Statically link the FTDI library

### DIFF
--- a/software/teachee-desktop/Cargo.toml
+++ b/software/teachee-desktop/Cargo.toml
@@ -8,6 +8,17 @@ eframe = "0.20.1"
 libftd2xx = "0.32.1"
 structopt = "0.3.26"
 
+[target.'cfg(any(windows,linux))'.dependencies.libftd2xx]
+version = "0.32.1"
+features = ["static"]
+
+[target.'cfg(macos)'.dependencies.libftd2xx]
+version = "0.32.1"
+
+[features]
+default = []
+static = ["libftd2xx/static"]
+
 [workspace]
 members = [
     ".",


### PR DESCRIPTION
The static library is bundled with the crate, no need to download a dynamic library (for Linux and Windows)
See: https://docs.rs/libftd2xx/latest/libftd2xx/

Signed-off-by: Eric Yang <e.yang@queensu.ca>