### PR TITLE
COBS Encoder Invalid Packet Fix

### DIFF
--- a/rtl/examples/xadc_axis/xadc_axis.xpr
+++ b/rtl/examples/xadc_axis/xadc_axis.xpr
@@ -96,6 +96,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../verilog-axis/rtl/axis_adapter.v">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../../verilog-axis/rtl/axis_async_fifo.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -117,6 +124,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../axis/axis_adapter_wrapper.sv">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../../axis/axis_async_fifo_wrapper.sv">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -125,6 +139,13 @@
         </FileInfo>
       </File>
       <File Path="$PPRDIR/../../axis/axis_interface.sv">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
+      <File Path="$PPRDIR/../../cobs/cobs_axis_adapter_wrapper.sv">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
@@ -159,14 +180,7 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../../xadc/xadc_drp_axis_adapter.sv">
-        <FileInfo>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="implementation"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
-      <File Path="$PPRDIR/../../xadc/xadc_packetizer.sv">
+      <File Path="$PPRDIR/../../xadc/xadc_drp_axis_single_stream.sv">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
@@ -180,31 +194,23 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../xadc/xadc_drp_axis_adapter.sv">
+        <FileInfo>
+          <Attr Name="AutoDisabled" Val="1"/>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
+      <File Path="$PPRDIR/../../xadc/xadc_packetizer.sv">
+        <FileInfo>
+          <Attr Name="AutoDisabled" Val="1"/>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../../xadc/xadc_packet_package.sv">
-        <FileInfo>
-          <Attr Name="AutoDisabled" Val="1"/>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="implementation"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
-      <File Path="$PPRDIR/../../verilog-axis/rtl/axis_adapter.v">
-        <FileInfo>
-          <Attr Name="AutoDisabled" Val="1"/>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="implementation"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
-      <File Path="$PPRDIR/../../axis/axis_adapter_wrapper.sv">
-        <FileInfo>
-          <Attr Name="AutoDisabled" Val="1"/>
-          <Attr Name="UsedIn" Val="synthesis"/>
-          <Attr Name="UsedIn" Val="implementation"/>
-          <Attr Name="UsedIn" Val="simulation"/>
-        </FileInfo>
-      </File>
-      <File Path="$PPRDIR/../../cobs/cobs_axis_adapter_wrapper.sv">
         <FileInfo>
           <Attr Name="AutoDisabled" Val="1"/>
           <Attr Name="UsedIn" Val="synthesis"/>

--- a/rtl/examples/xadc_axis/xadc_reader.py
+++ b/rtl/examples/xadc_axis/xadc_reader.py
@@ -9,6 +9,12 @@ with Device('FT84Y22T') as dev:
     # takes us from async to sync mode within ft245.
     # if you don't run this the clock does not come up
     dev.ftdi_fn.ftdi_set_bitmode(1, 0x40)
-    while(True):
-        # print(dev.read(1))
-        print(int.from_bytes(dev.read(1), "big"))
+    data = dev.read(20_000)
+    anomaly_counter = 0
+    for i in range(1, len(data)):
+        print(data[i])
+        if data[i - 1] == 0 and data[i] > 5:
+            anomaly_counter += 1
+
+    print("found %d anomalies" % anomaly_counter)
+

--- a/rtl/teachee/teachee.xpr
+++ b/rtl/teachee/teachee.xpr
@@ -525,9 +525,7 @@
   <Runs Version="1" Minor="19">
     <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7a35tcpg236-1" ConstrsSet="constrs_1" Description="Vivado Synthesis Defaults" AutoIncrementalCheckpoint="true" IncrementalCheckpoint="$PSRCDIR/utils_1/imports/synth_1/teachee.dcp" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/synth_1" IncludeInArchive="true" IsChild="false" AutoIncrementalDir="$PSRCDIR/utils_1/imports/synth_1" AutoRQSDir="$PSRCDIR/utils_1/imports/synth_1">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2022">
-          <Desc>Vivado Synthesis Defaults</Desc>
-        </StratHandle>
+        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2022"/>
         <Step Id="synth_design"/>
       </Strategy>
       <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
@@ -537,9 +535,7 @@
     </Run>
     <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a35tcpg236-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2022">
-          <Desc>Default settings for Implementation.</Desc>
-        </StratHandle>
+        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2022"/>
         <Step Id="init_design"/>
         <Step Id="opt_design"/>
         <Step Id="power_opt_design"/>

--- a/rtl/xadc/xadc_drp_axis_adapter.sv
+++ b/rtl/xadc/xadc_drp_axis_adapter.sv
@@ -74,13 +74,9 @@ module xadc_drp_axis_adapter (
                 // Init both AXIS Sinks
                 xadc_current_axis.tdata <= 0;
                 xadc_current_axis.tvalid <= 0;
-                xadc_current_axis.tlast <= 1;
-                xadc_current_axis.tkeep <= 0;
 
                 xadc_voltage_axis.tdata <= 0;
                 xadc_voltage_axis.tvalid <= 0;
-                xadc_voltage_axis.tlast <= 1;
-                xadc_voltage_axis.tkeep <= 0;
 
                 xadc_daddr <= XADC_DRP_ADDR_VOLTAGE_CHANNEL;
                 xadc_den <= 0;

--- a/rtl/xadc/xadc_drp_axis_single_stream.sv
+++ b/rtl/xadc/xadc_drp_axis_single_stream.sv
@@ -3,7 +3,7 @@
 
 import xadc_drp_package::*;
 
-module xadc_drp_axis_adapter (
+module xadc_drp_axis_single_stream (
     // Xilinx XADC IP Interface (Only putting through the required signals)
     input var logic xadc_dclk,
     input var logic xadc_reset,
@@ -16,8 +16,7 @@ module xadc_drp_axis_adapter (
     input var logic xadc_eos,
 
     // ADC Channel AXI Streams
-    axis_interface.Source current_monitor_channel,
-    axis_interface.Source voltage_channel
+    axis_interface.Source sample_stream
 );
 
     typedef enum int {
@@ -25,10 +24,10 @@ module xadc_drp_axis_adapter (
         XADC_AXIS_AWAIT_EOS,
         XADC_AXIS_START_DRP_VOLTAGE_READ,
         XADC_AXIS_AWAIT_VOLTAGE_DATA,
-        XADC_AXIS_SEND_TO_VOLTAGE_FIFO,
+        XADC_AXIS_STORE_VOLTAGE_DATA,
         XADC_AXIS_START_DRP_CURRENT_READ,
         XADC_AXIS_AWAIT_CURRENT_DATA,
-        XADC_AXIS_SEND_TO_CURRENT_FIFO
+        XADC_AXIS_SEND_TO_SAMPLE_FIFO
     } xadc_drp_axis_adapter_state_t;
 
     xadc_drp_axis_adapter_state_t state = XADC_AXIS_INIT;
@@ -36,15 +35,8 @@ module xadc_drp_axis_adapter (
     // Define AXI Stream Interfaces
     // These interfaces will be tagged as sinks into the FIFO
     axis_interface #(
-        .DATA_WIDTH(XADC_DRP_DATA_WIDTH)
-    ) xadc_current_axis (
-        .clk(xadc_dclk),
-        .rst(xadc_reset)
-    );
-
-    axis_interface #(
-        .DATA_WIDTH(XADC_DRP_DATA_WIDTH)
-    ) xadc_voltage_axis (
+        .DATA_WIDTH(2 * XADC_DRP_DATA_WIDTH)
+    ) xadc_sample_data_axis (
         .clk(xadc_dclk),
         .rst(xadc_reset)
     );
@@ -52,35 +44,22 @@ module xadc_drp_axis_adapter (
     // Create Async FIFOs
     axis_async_fifo_wrapper #(
         .DEPTH(XADC_DRP_AXIS_FIFO_DEPTH),
-        .DATA_WIDTH(XADC_DRP_DATA_WIDTH),
+        .DATA_WIDTH(2 * XADC_DRP_DATA_WIDTH),
         .KEEP_ENABLE(0)
     ) xadc_current_fifo (
-        .sink(xadc_current_axis.Sink),
-        .source(current_monitor_channel)
+        .sink(xadc_sample_data_axis.Sink),
+        .source(sample_stream)
     );
 
-    axis_async_fifo_wrapper #(
-        .DEPTH(XADC_DRP_AXIS_FIFO_DEPTH),
-        .DATA_WIDTH(XADC_DRP_DATA_WIDTH),
-        .KEEP_ENABLE(0)
-    ) xadc_voltage_fifo (
-        .sink(xadc_voltage_axis.Sink),
-        .source(voltage_channel)
-    );
-
+    var logic [XADC_DRP_DATA_WIDTH-1:0] voltage_sample;
     always_ff @(posedge xadc_dclk) begin
         case (state)
             XADC_AXIS_INIT: begin
                 // Init both AXIS Sinks
-                xadc_current_axis.tdata <= 0;
-                xadc_current_axis.tvalid <= 0;
-                xadc_current_axis.tlast <= 1;
-                xadc_current_axis.tkeep <= 0;
-
-                xadc_voltage_axis.tdata <= 0;
-                xadc_voltage_axis.tvalid <= 0;
-                xadc_voltage_axis.tlast <= 1;
-                xadc_voltage_axis.tkeep <= 0;
+                xadc_sample_data_axis.tdata <= 0;
+                xadc_sample_data_axis.tvalid <= 0;
+                xadc_sample_data_axis.tlast <= 1;
+                xadc_sample_data_axis.tkeep <= 0;
 
                 xadc_daddr <= XADC_DRP_ADDR_VOLTAGE_CHANNEL;
                 xadc_den <= 0;
@@ -102,15 +81,8 @@ module xadc_drp_axis_adapter (
             end
             XADC_AXIS_AWAIT_VOLTAGE_DATA: begin
                 if (xadc_drdy) begin
-                    xadc_voltage_axis.tdata <= xadc_do;
-                    xadc_voltage_axis.tvalid <= 1;
+                    voltage_sample <= xadc_do;
 
-                    state <= XADC_AXIS_SEND_TO_VOLTAGE_FIFO;
-                end
-            end
-            XADC_AXIS_SEND_TO_VOLTAGE_FIFO: begin
-                if (xadc_voltage_axis.tready && xadc_voltage_axis.tvalid) begin
-                    xadc_voltage_axis.tvalid <= 0;
                     state <= XADC_AXIS_START_DRP_CURRENT_READ;
                 end
             end
@@ -123,15 +95,16 @@ module xadc_drp_axis_adapter (
             XADC_AXIS_AWAIT_CURRENT_DATA: begin
                 xadc_den <= 0;
                 if (xadc_drdy) begin
-                    xadc_current_axis.tdata <= xadc_do;
-                    xadc_current_axis.tvalid <= 1;
+                    xadc_sample_data_axis.tdata[XADC_DRP_DATA_WIDTH-1:0] <= xadc_do;
+                    xadc_sample_data_axis.tdata[2*XADC_DRP_DATA_WIDTH - 1:XADC_DRP_DATA_WIDTH] <= voltage_sample;
+                    xadc_sample_data_axis.tvalid <= 1;
 
-                    state <= XADC_AXIS_SEND_TO_CURRENT_FIFO;
+                    state <= XADC_AXIS_SEND_TO_SAMPLE_FIFO;
                 end
             end
-            XADC_AXIS_SEND_TO_CURRENT_FIFO: begin
-                if (xadc_current_axis.tready && xadc_current_axis.tvalid) begin
-                    xadc_current_axis.tvalid <= 0;
+            XADC_AXIS_SEND_TO_SAMPLE_FIFO: begin
+                if (xadc_sample_data_axis.tready && xadc_sample_data_axis.tvalid) begin
+                    xadc_sample_data_axis.tvalid <= 0;
 
                     state <= XADC_AXIS_AWAIT_EOS;
                 end
@@ -141,17 +114,11 @@ module xadc_drp_axis_adapter (
 
     // Set default values for the unused AXIS signals
     always_comb begin
-        xadc_current_axis.tlast = 1;
-        xadc_current_axis.tkeep = '1;
-        xadc_current_axis.tid = '0;
-        xadc_current_axis.tuser = '0;
-        xadc_current_axis.tdest = '0;
-
-        xadc_voltage_axis.tlast = 1;
-        xadc_voltage_axis.tkeep = '1;
-        xadc_voltage_axis.tid = '0;
-        xadc_voltage_axis.tuser = '0;
-        xadc_voltage_axis.tdest = '0;
+        xadc_sample_data_axis.tlast = 1;
+        xadc_sample_data_axis.tkeep = '1;
+        xadc_sample_data_axis.tid = '0;
+        xadc_sample_data_axis.tuser = '0;
+        xadc_sample_data_axis.tdest = '0;
     end
 endmodule
 

--- a/rtl/xadc/xadc_drp_axis_single_stream.sv
+++ b/rtl/xadc/xadc_drp_axis_single_stream.sv
@@ -58,8 +58,6 @@ module xadc_drp_axis_single_stream (
                 // Init both AXIS Sinks
                 xadc_sample_data_axis.tdata <= 0;
                 xadc_sample_data_axis.tvalid <= 0;
-                xadc_sample_data_axis.tlast <= 1;
-                xadc_sample_data_axis.tkeep <= 0;
 
                 xadc_daddr <= XADC_DRP_ADDR_VOLTAGE_CHANNEL;
                 xadc_den <= 0;

--- a/rtl/xadc/xadc_packetizer.sv
+++ b/rtl/xadc/xadc_packetizer.sv
@@ -145,6 +145,7 @@ module xadc_packetizer (
                 // indicate that we are no longer ready for data from the current and voltage stream
                 voltage_channel.tready <= 0;
                 current_monitor_channel.tready <= 0;
+                raw_stream.tlast <= 0;
 
                 state <= XADC_PACKETIZER_INIT;
             end

--- a/rtl/xadc/xadc_packetizer.sv
+++ b/rtl/xadc/xadc_packetizer.sv
@@ -147,7 +147,13 @@ module xadc_packetizer (
                 current_monitor_channel.tready <= 0;
                 raw_stream.tlast <= 0;
 
-                state <= XADC_PACKETIZER_INIT;
+                if (voltage_channel.tvalid && current_monitor_channel.tvalid) begin
+                    // Wait until we have valid data before starting another load
+                    voltage_channel.tready <= 1;
+                    current_monitor_channel.tready <= 1;
+
+                    state <= XADC_PACKETIZER_LOAD_NEW_SAMPLES;
+                end
             end
         endcase
     end

--- a/rtl/xadc/xadc_packetizer.sv
+++ b/rtl/xadc/xadc_packetizer.sv
@@ -147,13 +147,7 @@ module xadc_packetizer (
                 current_monitor_channel.tready <= 0;
                 raw_stream.tlast <= 0;
 
-                if (voltage_channel.tvalid && current_monitor_channel.tvalid) begin
-                    // Wait until we have valid data before starting another load
-                    voltage_channel.tready <= 1;
-                    current_monitor_channel.tready <= 1;
-
-                    state <= XADC_PACKETIZER_LOAD_NEW_SAMPLES;
-                end
+                state <= XADC_PACKETIZER_INIT;
             end
         endcase
     end

--- a/rtl/xadc/xadc_packetizer.sv
+++ b/rtl/xadc/xadc_packetizer.sv
@@ -145,7 +145,7 @@ module xadc_packetizer (
                 // indicate that we are no longer ready for data from the current and voltage stream
                 voltage_channel.tready <= 0;
                 current_monitor_channel.tready <= 0;
-                raw_stream.tlast <= 0;
+                // raw_stream.tlast <= 0;
 
                 state <= XADC_PACKETIZER_INIT;
             end


### PR DESCRIPTION
The XADC packetizer was occasionally sending broken packets. The issue appears to lie with the assertion of the tlast signal. I held this high for two cycles instead of 1 causing some inconsistent behaviour.