### PR TITLE
Use new packet format

### DIFF
--- a/software/teachee-desktop/src/app.rs
+++ b/software/teachee-desktop/src/app.rs
@@ -338,13 +338,13 @@ impl eframe::App for App {
             // TODO: get the actual sample period
             // TODO: Scale and offset
             let voltage = plot::Line::new(plot::PlotPoints::from_parametric_callback(
-                |i| (i * 0.01, channels.voltage1[i as usize]),
+                |i| (i * 0.000001, channels.voltage1[i as usize]),
                 0.0..(num_samples as f64),
                 num_samples,
             ))
             .name("Channel 1");
             let current = plot::Line::new(plot::PlotPoints::from_parametric_callback(
-                |i| (i * 0.01, channels.current1[i as usize]),
+                |i| (i * 0.000001, channels.current1[i as usize]),
                 0.0..(num_samples as f64),
                 num_samples,
             ))
@@ -356,11 +356,11 @@ impl eframe::App for App {
             condvar.notify_one();
 
             plot::Plot::new("plot")
-                .data_aspect(1.0)
-                .allow_drag(false)
-                .allow_scroll(false)
-                .allow_zoom(false)
-                .allow_boxed_zoom(false)
+                // .data_aspect(1.0)
+                // .allow_drag(false)
+                // .allow_scroll(false)
+                // .allow_zoom(false)
+                // .allow_boxed_zoom(false)
                 .legend(plot::Legend::default())
                 .show(ui, |ui| {
                     ui.line(voltage);

--- a/software/teachee-desktop/src/app.rs
+++ b/software/teachee-desktop/src/app.rs
@@ -30,6 +30,9 @@ const GROUP_SPACING: f32 = 3.0;
 const BUTTON_HEIGHT: f32 = 25.0;
 const TEXTEDIT_WIDTH: f32 = 30.0;
 
+// 1 MSPS
+const SAMPLE_PERIOD: f64 = 1e-6;
+
 #[derive(Debug, Default)]
 struct UIControls {
     h_offset: f64,
@@ -335,16 +338,15 @@ impl eframe::App for App {
 
             let (channels, num_samples) = buf_state.unwrap();
             // Mapping i -> t using the fixed sample rate to get point (i * period, samples[i]).
-            // TODO: get the actual sample period
             // TODO: Scale and offset
             let voltage = plot::Line::new(plot::PlotPoints::from_parametric_callback(
-                |i| (i * 0.000001, channels.voltage1[i as usize]),
+                |i| (i * SAMPLE_PERIOD, channels.voltage1[i as usize]),
                 0.0..(num_samples as f64),
                 num_samples,
             ))
             .name("Channel 1");
             let current = plot::Line::new(plot::PlotPoints::from_parametric_callback(
-                |i| (i * 0.000001, channels.current1[i as usize]),
+                |i| (i * SAMPLE_PERIOD, channels.current1[i as usize]),
                 0.0..(num_samples as f64),
                 num_samples,
             ))
@@ -356,11 +358,6 @@ impl eframe::App for App {
             condvar.notify_one();
 
             plot::Plot::new("plot")
-                // .data_aspect(1.0)
-                // .allow_drag(false)
-                // .allow_scroll(false)
-                // .allow_zoom(false)
-                // .allow_boxed_zoom(false)
                 .legend(plot::Legend::default())
                 .show(ui, |ui| {
                     ui.line(voltage);

--- a/software/teachee-desktop/src/controller.rs
+++ b/software/teachee-desktop/src/controller.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 // Number of samples in each channel's buffer
-const BUF_SIZE: usize = 1000;
+const BUF_SIZE: usize = 65536;
 const NUM_BUFS: usize = 2;
 
 #[derive(Debug)]

--- a/software/teachee-desktop/src/sample_source/ft.rs
+++ b/software/teachee-desktop/src/sample_source/ft.rs
@@ -1,4 +1,3 @@
-use core::num;
 use std::{iter::zip, thread, time::Duration, cmp::{max, min}};
 
 use libftd2xx::{BitMode, Ft232h, FtdiCommon};
@@ -10,7 +9,7 @@ use super::{Channel, Result, SampleSource};
 const MASK: u8 = 0xFF;
 const LATENCY_TIMER: Duration = Duration::from_millis(16);
 const IN_TRANSFER_SIZE: u32 = 0x10000;
-const RX_BUF_SIZE: usize = 100_000;
+const RX_BUF_SIZE: usize = 10000;
 const PACKET_SIZE: usize = 6;
 
 /// A sample source that reads from a real TeachEE device.
@@ -49,13 +48,9 @@ impl SampleSource for FtSampleSource {
 
 impl FtSampleSource {
     fn read_bytes(&mut self) -> Result<usize> {
-        let mut num_bytes = self.ft.queue_status()?;
-        println!("{num_bytes}");
-        num_bytes = 10000;
+        self.ft.read_all(&mut self.rx_buf)?;
 
-        self.ft.read_all(&mut self.rx_buf[0..num_bytes])?;
-        
-        Ok(num_bytes)
+        Ok(RX_BUF_SIZE)
     }
     fn decode_and_copy(&mut self, channels: &mut Channels, num_bytes: usize) -> usize {
         // Position after first 0
@@ -72,48 +67,53 @@ impl FtSampleSource {
                 .rev()
                 .position(|&x| x == 0)
                 .unwrap();
-        // Check that we have at least one packet
-        debug_assert_ne!(start, end);
-        debug_assert_eq!((end - start) % PACKET_SIZE, 0, "{start} {end}");
+        let mut src_index = start;
+        let mut dst_index = 0;
 
-        for (packet, (v_sample, c_sample)) in self.rx_buf[start..end].chunks_exact(PACKET_SIZE).zip(
-            zip(channels.voltage1.iter_mut(), channels.current1.iter_mut()),
-        ) {
-            debug_assert!(
-                packet[0] < PACKET_SIZE as u8,
-                "Unexpected block size: {}",
-                packet[0]
-            );
-            debug_assert_eq!(packet[5], 0);
-            // if packet[0] == 5 {
-            //     // Fast path
-            //     *v_sample = (((packet[4] as u16) << 4) | packet[3] as u16) as f64 * 3.3 / 4095.0;
-            //     *c_sample = (((packet[2] as u16) << 4) | packet[1] as u16) as f64 * 15.0 / 4095.0;
-            // } else {
+        while src_index + 6 < end && dst_index < channels.voltage1.len() {
+            // Packet error: offset byte not in [1, 5] or packet not delimited with 0
+            if self.rx_buf[src_index] == 0 || self.rx_buf[src_index] > 5 || self.rx_buf[src_index + 5] != 0 {
+                // Find the next 0
+                // Note that the +5 skips at least 1 packet, +6 would skip at least this and the next.
+                match self.rx_buf[(src_index + 5)..(end - 1)].iter().position(|&x| x == 0) {
+                    Some(i) => {
+                        // Advance to the next packet (which follows the 0)
+                        src_index += i + 1;
+                        debug_assert!(src_index + 6 <= end, "{src_index} {end}");
+                    },
+                    None => {
+                        // No more valid packets or the erroneous packet was the last
+                        break;
+                    }
+                }
+            } else {
+                let packet = &self.rx_buf[src_index..(src_index + 6)];
                 let mut block = packet[0] - 1;
                 // Two bytes of packet overhead
                 let mut decoded: [u8; PACKET_SIZE - 2] = [0; PACKET_SIZE - 2];
-                let mut dst_index = 0;
+                let mut decoded_index = 0;
 
-                // Note: the packet index is just the dst_index + 1 (skip the first offset byte)
+                // Note: the packet index is just the decoded_index + 1 (skip the first offset byte)
                 // Example packet: 01 02 22 02 44 00
                 // Decodes to:        00 22 00 44
-                while dst_index < decoded.len() {
+                while decoded_index < decoded.len() {
                     if block > 0 {
-                        decoded[dst_index] = packet[dst_index + 1];
+                        decoded[decoded_index] = packet[decoded_index + 1];
                     } else {
-                        decoded[dst_index] = 0;
-                        block = packet[dst_index + 1];
+                        decoded[decoded_index] = 0;
+                        block = packet[decoded_index + 1];
                     }
-                    dst_index += 1;
+                    decoded_index += 1;
                     block -= 1;
                 }
 
-                *v_sample = (((decoded[3] as u16) << 4) | decoded[2] as u16) as f64 * 3.3 / 4095.0;
-                *c_sample = ((((decoded[1] as u16) << 4) | decoded[0] as u16) as f64 * 3.3 / 4095.0 - 1.5) * (1.0 / 0.09);
-            // }
+                channels.voltage1[dst_index] = (((decoded[3] as u16) << 4) | decoded[2] as u16) as f64 * 3.3 / 4095.0;
+                channels.current1[dst_index] = ((((decoded[1] as u16) << 4) | decoded[0] as u16) as f64 * 3.3 / 4095.0 - 1.5) * (1.0 / 0.09);
+                src_index += 6;
+                dst_index += 1;
+            }
         }
 
-        (end - start) / PACKET_SIZE
+        dst_index
     }
 }

--- a/software/teachee-desktop/src/sample_source/ft.rs
+++ b/software/teachee-desktop/src/sample_source/ft.rs
@@ -73,12 +73,21 @@ impl FtSampleSource {
         while src_index + 6 < end && dst_index < channels.voltage1.len() {
             // Packet error: offset byte not in [1, 5] or packet not delimited with 0
             if self.rx_buf[src_index] == 0 || self.rx_buf[src_index] > 5 || self.rx_buf[src_index + 5] != 0 {
+                println!("Packet Error {src_index}");
+                for val in self.rx_buf[src_index..(src_index + 6)].iter() {
+                    print!("{val}, ");
+                }
+                println!("");
                 // Find the next 0
                 // Note that the +5 skips at least 1 packet, +6 would skip at least this and the next.
-                match self.rx_buf[(src_index + 5)..(end - 1)].iter().position(|&x| x == 0) {
+                match self.rx_buf[(src_index + 1)..(end - 1)].iter().position(|&x| x == 0) {
                     Some(i) => {
                         // Advance to the next packet (which follows the 0)
-                        src_index += i + 1;
+                        src_index += i + 2;
+                        for val in self.rx_buf[src_index..(src_index + 6)].iter() {
+                            print!("{val}, ");
+                        }
+                        println!("");
                         debug_assert!(src_index + 6 <= end, "{src_index} {end}");
                     },
                     None => {

--- a/software/teachee-desktop/src/sample_source/ft.rs
+++ b/software/teachee-desktop/src/sample_source/ft.rs
@@ -81,8 +81,8 @@ impl FtSampleSource {
             debug_assert_eq!(packet[5], 0);
             if packet[0] == 5 {
                 // Fast path
-                *v_sample = ((packet[1] << 4) | packet[2]) as f64 * 3.3 / 4095.0;
-                *c_sample = ((packet[3] << 4) | packet[4]) as f64 * 3.3 / 4095.0;
+                *v_sample = (((packet[4] as u16) << 4) | packet[3] as u16) as f64 * 3.3 / 4095.0;
+                *c_sample = (((packet[2] as u16) << 4) | packet[1] as u16) as f64 * 15.0 / 4095.0;
             } else {
                 let mut block = packet[0] - 1;
                 // Two bytes of packet overhead
@@ -103,8 +103,8 @@ impl FtSampleSource {
                     block -= 1;
                 }
 
-                *v_sample = ((decoded[0] << 4) | decoded[1]) as f64 * 3.3 / 4095.0;
-                *c_sample = ((decoded[2] << 4) | decoded[3]) as f64 * 3.3 / 4095.0;
+                *v_sample = (((decoded[3] as u16) << 4) | decoded[2] as u16) as f64 * 3.3 / 4095.0;
+                *c_sample = (((decoded[1] as u16) << 4) | decoded[0] as u16) as f64 * 3.3 / 4095.0;
             }
         }
 


### PR DESCRIPTION
New packet format is the old one but sample bytes are reversed. 
Scale current samples properly.
Don't crash if a bad packet is encountered, instead skip it.

We are hardcoding 10000 as the number of bytes to read from the driver because 1. We don't want the horizontal scale to fluctuate and 2. Reading any more than 10000 causes the usb thread to block (waiting for more bytes from the driver), which decreases performance.