### PR TITLE
Implement hysteresis triggering (enabled by default)

### DIFF
--- a/software/teachee-desktop/Cargo.toml
+++ b/software/teachee-desktop/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.32.1"
 
 [features]
 default = []
+window_trigger = []
 static = ["libftd2xx/static"]
 
 [workspace]


### PR DESCRIPTION
Old sliding window triggering implementation can be enabled by passing "-F window_trigger" to cargo run:

`cargo run -F window_trigger`

Note that this flag controls conditional compilation of the triggering algorithms (so different implementations are enabled at build and not run time).