### PR TITLE
Make CSV error handling consistent with existing

### DIFF
--- a/software/teachee-desktop/Cargo.lock
+++ b/software/teachee-desktop/Cargo.lock
@@ -540,31 +540,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -680,12 +659,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "emath"
@@ -1164,26 +1137,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "native-dialog"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab637f328b31bd0855c43bd38a4a4455e74324d9e74e0aac6a803422f43abc6"
-dependencies = [
- "block",
- "cocoa",
- "dirs-next",
- "objc",
- "objc-foundation",
- "objc_id",
- "once_cell",
- "raw-window-handle 0.4.3",
- "thiserror",
- "wfd",
- "which",
- "winapi",
 ]
 
 [[package]]
@@ -1722,7 +1675,6 @@ dependencies = [
  "csv",
  "eframe",
  "libftd2xx",
- "native-dialog",
  "structopt",
 ]
 
@@ -2080,27 +2032,6 @@ dependencies = [
  "url",
  "web-sys",
  "windows 0.43.0",
-]
-
-[[package]]
-name = "wfd"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e713040b67aae5bf1a0ae3e1ebba8cc29ab2b90da9aa1bff6e09031a8a41d7a8"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/software/teachee-desktop/Cargo.toml
+++ b/software/teachee-desktop/Cargo.toml
@@ -8,7 +8,6 @@ eframe = "0.20.1"
 libftd2xx = "0.32.1"
 structopt = "0.3.26"
 csv = "1.2.1"
-native-dialog = "0.6.3"
 
 [target.'cfg(any(windows,linux))'.dependencies.libftd2xx]
 version = "0.32.1"


### PR DESCRIPTION
- Upon CSV export error, turn button red and display error as tooltip. This is what the trigger error handling does.
Also, removing the unused native-dialog crate reduces build size from 1.47 GB to 1.13 GB on my Windows machine.
- Delete empty file if CSV writing fails.